### PR TITLE
change: support using system packages with custom variant

### DIFF
--- a/patch/loader.py
+++ b/patch/loader.py
@@ -37,7 +37,17 @@ def _load_shared_library(preload_target: _PreloadTarget) -> None:
         preload_target: preload target
     """
     logger.debug("Try to load shared library in package.", extra=preload_target)
-    for file in distribution(preload_target["package"]).files:
+
+    package = preload_target.get("package", None)
+    if package is None:
+        ctypes.CDLL(preload_target["library"], mode=ctypes.RTLD_GLOBAL)
+        logger.debug(
+            "Finish to load shared library from system, as no package is specified.",
+            extra=preload_target,
+        )
+        return
+
+    for file in distribution(package).files:
         if preload_target["library"] == file.name:
             path = str(file.locate())
             break


### PR DESCRIPTION
Took a deeper look at #101

I think this change may be reasonable based on our discussion there.

Essentially, if `package` is not set in an entry in `_preload_library.json`, we will allow using the system-level package.

I am using this patch when creating my own variant, but figure it may be valuable/safe to upstream.

To address the note:

> I might add changes to allow users to use system CUDA at their own risk.
> (Though I don’t intend to change the default behavior)

I think this does this because all default builds are guaranteed to have `package` set in this file, so this is a noop for all the default/pypi-uploaded builds