### PR TITLE
chore: update ruff to 0.12.8

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 uv = "0.6.17"
 dagger = "0.18.5"
 typos = "1.31.1"
-ruff = '0.11.7'
+ruff = '0.12.8'
 taplo = "0.9.3"
 
 [settings]

--- a/script/generate_pyproject.py
+++ b/script/generate_pyproject.py
@@ -144,9 +144,8 @@ pytest {project}/faiss/faiss/gpu/test/torch_test_contrib_gpu.py
     repair_option = " ".join(
         [i for v in config["python"]["preload-library"] for i in ["--exclude", v["library"]]]
     )
-    pyproject["tool"]["cibuildwheel"]["linux"]["before-all"] = (
-        f"{' '.join([f'{k}="{v}"' for k, v in build_envs.items()])} script/build.sh"
-    )
+    env_vars = " ".join([f'{k}="{v}"' for k, v in build_envs.items()])
+    pyproject["tool"]["cibuildwheel"]["linux"]["before-all"] = f"{env_vars} script/build.sh"
     pyproject["tool"]["cibuildwheel"]["linux"]["environment-pass"] += enviromnet_pass
     pyproject["tool"]["cibuildwheel"]["linux"]["environment"] |= envs
     pyproject["tool"]["cibuildwheel"]["linux"]["before-test"] = (


### PR DESCRIPTION
## Summary
- Update ruff version from 0.11.7 to 0.12.8 in mise.toml
- Improve code formatting in generate_pyproject.py to comply with ruff 0.12.8 standards

## Test plan
- [x] Run `ruff check .` to verify no linting errors
- [x] Run `ruff format --check .` to verify formatting is correct