### PR TITLE
Update Faiss to v1.12.0

### DIFF
--- a/script/template/pyproject.toml.tpl
+++ b/script/template/pyproject.toml.tpl
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = ["numpy<2", "packaging"]
 requires-python = ">=3.9,<3.13"
 authors = [{ name = "Di-Is", email = "rhoxbox@gmail.com" }]

--- a/variant/cpu/pyproject.toml
+++ b/variant/cpu/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-cpu"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = ["numpy<2", "packaging"]
 requires-python = ">=3.9,<3.13"
 authors = [{ name = "Di-Is", email = "rhoxbox@gmail.com" }]

--- a/variant/gpu-cu11/pyproject.toml
+++ b/variant/gpu-cu11/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-gpu-cu11"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
     "numpy<2",
     "packaging",

--- a/variant/gpu-cu12/pyproject.toml
+++ b/variant/gpu-cu12/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-gpu-cu12"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
     "numpy<2",
     "packaging",


### PR DESCRIPTION
## Summary
- Update Faiss submodule to version 1.12.0
- Update pyproject.toml files for all build variants (GPU-CU11, GPU-CU12) to reflect new version