### PR TITLE
ci: run CPU tests against built wheels

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -71,13 +71,12 @@ jobs:
             echo "Wheel not found for ${py_tag} in wheelhouse" >&2
             exit 1
           fi
-          package_name="faiss-${{ matrix.variant }}"
           extras=""
           if [[ "${{ matrix.variant }}" == "gpu-cu11" || "${{ matrix.variant }}" == "gpu-cu12" ]]; then
             extras="[fix-cuda]"
           fi
           source "variant/${{ matrix.variant }}/.venv/bin/activate"
-          uv run --active --no-project --no-sync \
+          uv run --python "${{ matrix.python-version }}" --active --no-project --no-sync \
             --with "${wheel_path}${extras}" bash -lc \
             "pytest faiss/tests/ -n $((`nproc --all`/5+1)) && \
              pytest faiss/tests/torch_test_contrib.py -n $((`nproc --all`/5+1))"


### PR DESCRIPTION
## Summary
- Add CPU test job that installs built wheels and runs the same CPU tests as cibuildwheel.
- Sync dependencies with uv for each Python version.

## Variants
- gpu-cu11
- gpu-cu12

## Tests
- pytest faiss/tests/ -n 7
- pytest faiss/tests/torch_test_contrib.py -n 7