### PR TITLE
update: bump up faiss to v1.14.0

### DIFF
--- a/patch/modify-numpy-find-package.patch
+++ b/patch/modify-numpy-find-package.patch
@@ -6,18 +6,17 @@ This software is released under the MIT License.
 http://opensource.org/licenses/mit-license.php
 
 diff --git a/faiss/faiss/python/CMakeLists.txt b/faiss/faiss/python/CMakeLists.txt
-index ad431a3e0..8d4c20339 100644
 --- a/faiss/faiss/python/CMakeLists.txt
 +++ b/faiss/faiss/python/CMakeLists.txt
-@@ -71,7 +71,6 @@ configure_swigfaiss(swigfaiss_avx2.swig)
+@@ -76,7 +76,6 @@
  configure_swigfaiss(swigfaiss_avx512.swig)
  configure_swigfaiss(swigfaiss_avx512_spr.swig)
  configure_swigfaiss(swigfaiss_sve.swig)
 -configure_swigfaiss(faiss_example_external_module.swig)
- 
+
  if(TARGET faiss)
    # Manually add headers as extra dependencies of swigfaiss.
-@@ -87,8 +86,6 @@ if(TARGET faiss)
+@@ -92,8 +91,6 @@
        "${faiss_SOURCE_DIR}/faiss/${h}")
      list(APPEND SWIG_MODULE_swigfaiss_sve_EXTRA_DEPS
        "${faiss_SOURCE_DIR}/faiss/${h}")
@@ -26,7 +25,7 @@ index ad431a3e0..8d4c20339 100644
    endforeach()
    foreach(h ${FAISS_GPU_HEADERS})
      list(APPEND SWIG_MODULE_swigfaiss_EXTRA_DEPS
-@@ -101,8 +98,6 @@ if(TARGET faiss)
+@@ -106,8 +103,6 @@
        "${faiss_SOURCE_DIR}/faiss/gpu/${h}")
      list(APPEND SWIG_MODULE_swigfaiss_sve_EXTRA_DEPS
        "${faiss_SOURCE_DIR}/faiss/gpu/${h}")
@@ -35,10 +34,10 @@ index ad431a3e0..8d4c20339 100644
    endforeach()
  else()
    find_package(faiss REQUIRED)
-@@ -164,18 +159,8 @@ if(NOT FAISS_OPT_LEVEL STREQUAL "sve")
+@@ -176,18 +171,8 @@
    set_target_properties(swigfaiss_sve PROPERTIES EXCLUDE_FROM_ALL TRUE)
  endif()
- 
+
 -set_property(SOURCE faiss_example_external_module.swig
 -  PROPERTY SWIG_MODULE_NAME faiss_example_external_module)
 -swig_add_library(faiss_example_external_module
@@ -54,7 +53,7 @@ index ad431a3e0..8d4c20339 100644
  elseif(NOT WIN32)
    # NOTE: Python does not recognize the dylib extension.
    set_target_properties(swigfaiss PROPERTIES SUFFIX .so)
-@@ -183,7 +168,6 @@ elseif(NOT WIN32)
+@@ -195,7 +180,6 @@
    set_target_properties(swigfaiss_avx512 PROPERTIES SUFFIX .so)
    set_target_properties(swigfaiss_avx512_spr PROPERTIES SUFFIX .so)
    set_target_properties(swigfaiss_sve PROPERTIES SUFFIX .so)
@@ -62,23 +61,23 @@ index ad431a3e0..8d4c20339 100644
  else()
    # we need bigobj for the swig wrapper
    target_compile_options(swigfaiss PRIVATE /bigobj)
-@@ -191,7 +175,6 @@ else()
+@@ -203,7 +187,6 @@
    target_compile_options(swigfaiss_avx512 PRIVATE /bigobj)
    target_compile_options(swigfaiss_avx512_spr PRIVATE /bigobj)
    target_compile_options(swigfaiss_sve PRIVATE /bigobj)
 -  target_compile_options(faiss_example_external_module PRIVATE /bigobj)
  endif()
- 
+
  if(FAISS_ENABLE_SVS)
-@@ -200,7 +183,6 @@ if(FAISS_ENABLE_SVS)
+@@ -212,7 +195,6 @@
    target_compile_definitions(swigfaiss_avx512 PRIVATE FAISS_ENABLE_SVS FAISS_SVS_RUNTIME_VERSION=${FAISS_SVS_RUNTIME_VERSION})
    target_compile_definitions(swigfaiss_avx512_spr PRIVATE FAISS_ENABLE_SVS FAISS_SVS_RUNTIME_VERSION=${FAISS_SVS_RUNTIME_VERSION})
    target_compile_definitions(swigfaiss_sve PRIVATE FAISS_ENABLE_SVS FAISS_SVS_RUNTIME_VERSION=${FAISS_SVS_RUNTIME_VERSION})
 -  target_compile_definitions(faiss_example_external_module PRIVATE FAISS_ENABLE_SVS FAISS_SVS_RUNTIME_VERSION=${FAISS_SVS_RUNTIME_VERSION})
  endif()
- 
- if(FAISS_ENABLE_GPU)
-@@ -209,7 +191,6 @@ if(FAISS_ENABLE_GPU)
+
+ # Enable DD support in Python bindings when building with Dynamic Dispatch
+@@ -227,7 +209,6 @@
      target_link_libraries(swigfaiss_avx2 PRIVATE hip::host)
      target_link_libraries(swigfaiss_avx512 PRIVATE hip::host)
      target_link_libraries(swigfaiss_avx512_spr PRIVATE hip::host)
@@ -86,10 +85,10 @@ index ad431a3e0..8d4c20339 100644
    else()
      find_package(CUDAToolkit REQUIRED)
      if(FAISS_ENABLE_CUVS)
-@@ -260,14 +241,6 @@ target_link_libraries(swigfaiss_sve PRIVATE
+@@ -278,14 +259,6 @@
    OpenMP::OpenMP_CXX
  )
- 
+
 -target_link_libraries(faiss_example_external_module PRIVATE
 -  Python::Module
 -  Python::NumPy
@@ -101,19 +100,19 @@ index ad431a3e0..8d4c20339 100644
  # Hack so that python_callbacks.h can be included as
  # `#include <faiss/python/python_callbacks.h>`.
  target_include_directories(swigfaiss PRIVATE ${PROJECT_SOURCE_DIR}/../..)
-@@ -275,7 +248,6 @@ target_include_directories(swigfaiss_avx2 PRIVATE ${PROJECT_SOURCE_DIR}/../..)
+@@ -293,7 +266,6 @@
  target_include_directories(swigfaiss_avx512 PRIVATE ${PROJECT_SOURCE_DIR}/../..)
  target_include_directories(swigfaiss_avx512_spr PRIVATE ${PROJECT_SOURCE_DIR}/../..)
  target_include_directories(swigfaiss_sve PRIVATE ${PROJECT_SOURCE_DIR}/../..)
 -target_include_directories(faiss_example_external_module PRIVATE ${PROJECT_SOURCE_DIR}/../..)
- 
+
  find_package(Python REQUIRED
    COMPONENTS Development.Module NumPy
-@@ -302,7 +274,6 @@ target_link_libraries(swigfaiss_avx2 PRIVATE faiss_python_callbacks)
+@@ -320,7 +292,6 @@
  target_link_libraries(swigfaiss_avx512 PRIVATE faiss_python_callbacks)
  target_link_libraries(swigfaiss_avx512_spr PRIVATE faiss_python_callbacks)
  target_link_libraries(swigfaiss_sve PRIVATE faiss_python_callbacks)
 -target_link_libraries(faiss_example_external_module PRIVATE faiss_python_callbacks)
- 
+
  configure_file(setup.py setup.py COPYONLY)
  configure_file(__init__.py __init__.py COPYONLY)

--- a/script/template/pyproject.toml.tpl
+++ b/script/template/pyproject.toml.tpl
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = ["numpy>=2,<3", "packaging"]
 requires-python = ">=3.10,<3.14"
 authors = [{ name = "Di-Is", email = "rhoxbox@gmail.com" }]

--- a/variant/cpu/pyproject.toml
+++ b/variant/cpu/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-cpu"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = ["numpy>=2,<3", "packaging"]
 requires-python = ">=3.10,<3.14"
 authors = [{ name = "Di-Is", email = "rhoxbox@gmail.com" }]

--- a/variant/cpu/uv.lock
+++ b/variant/cpu/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "faiss-cpu"
-version = "1.13.2"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/variant/gpu-cu11/pyproject.toml
+++ b/variant/gpu-cu11/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-gpu-cu11"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
     "numpy>=2,<3",
     "packaging",

--- a/variant/gpu-cu11/uv.lock
+++ b/variant/gpu-cu11/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "faiss-gpu-cu11"
-version = "1.13.2"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/variant/gpu-cu12/pyproject.toml
+++ b/variant/gpu-cu12/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-gpu-cu12"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
     "numpy>=2,<3",
     "packaging",

--- a/variant/gpu-cu12/uv.lock
+++ b/variant/gpu-cu12/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "faiss-gpu-cu12"
-version = "1.13.2"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary
- Update FAISS submodule from v1.13.2 to v1.14.0
- Regenerate `patch/modify-numpy-find-package.patch` for v1.14.0 CMakeLists.txt structure (new DD support, visibility settings)
- Update version in template and regenerate all variant pyproject.toml / uv.lock files

## Test plan
- [ ] Add `build` label to trigger CI wheel build
- [ ] Verify GPU test suite passes (cu11, cu12)
