### PR TITLE
Bump version to 1.14.1 and update faiss submodule

### DIFF
--- a/script/template/pyproject.toml.tpl
+++ b/script/template/pyproject.toml.tpl
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = ["numpy>=2,<3", "packaging"]
 requires-python = ">=3.10,<3.14"
 authors = [{ name = "Di-Is", email = "rhoxbox@gmail.com" }]

--- a/variant/cpu/pyproject.toml
+++ b/variant/cpu/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-cpu"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = ["numpy>=2,<3", "packaging"]
 requires-python = ">=3.10,<3.14"
 authors = [{ name = "Di-Is", email = "rhoxbox@gmail.com" }]

--- a/variant/cpu/uv.lock
+++ b/variant/cpu/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "faiss-cpu"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/variant/gpu-cu11/pyproject.toml
+++ b/variant/gpu-cu11/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-gpu-cu11"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
     "numpy>=2,<3",
     "packaging",

--- a/variant/gpu-cu11/uv.lock
+++ b/variant/gpu-cu11/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "faiss-gpu-cu11"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/variant/gpu-cu12/pyproject.toml
+++ b/variant/gpu-cu12/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-gpu-cu12"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
     "numpy>=2,<3",
     "packaging",

--- a/variant/gpu-cu12/uv.lock
+++ b/variant/gpu-cu12/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "faiss-gpu-cu12"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary
This release updates the faiss library to a newer commit and bumps the package version to 1.14.1 across all variants.

## Key Changes
- Updated faiss submodule from `e56d96aa01c14eda55def5d4fea2046ac96dcab8` to `471ddad72cb617dcce9f11966ed991a71609d49b`
- Bumped version from 1.14.0 to 1.14.1 in:
  - `script/template/pyproject.toml.tpl` (base template)
  - `variant/cpu/pyproject.toml` (CPU variant)
  - `variant/gpu-cu11/pyproject.toml` (GPU CUDA 11 variant)
  - `variant/gpu-cu12/pyproject.toml` (GPU CUDA 12 variant)

## Details
This is a patch release that incorporates upstream faiss improvements and updates all package variants to maintain version consistency across the CPU and GPU distributions.

https://claude.ai/code/session_01H5fGmWmR91iWn3m7e4HEhr