### PR TITLE
fix: rebuild against re-released faiss v1.14.1

### DIFF
--- a/script/template/pyproject.toml.tpl
+++ b/script/template/pyproject.toml.tpl
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss"
-version = "1.14.1"
+version = "1.14.1.post1"
 dependencies = ["numpy>=2,<3", "packaging"]
 requires-python = ">=3.10,<3.14"
 authors = [{ name = "Di-Is", email = "rhoxbox@gmail.com" }]

--- a/variant/cpu/pyproject.toml
+++ b/variant/cpu/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-cpu"
-version = "1.14.1"
+version = "1.14.1.post1"
 dependencies = ["numpy>=2,<3", "packaging"]
 requires-python = ">=3.10,<3.14"
 authors = [{ name = "Di-Is", email = "rhoxbox@gmail.com" }]

--- a/variant/gpu-cu11/pyproject.toml
+++ b/variant/gpu-cu11/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-gpu-cu11"
-version = "1.14.1"
+version = "1.14.1.post1"
 dependencies = [
     "numpy>=2,<3",
     "packaging",

--- a/variant/gpu-cu12/pyproject.toml
+++ b/variant/gpu-cu12/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "faiss-gpu-cu12"
-version = "1.14.1"
+version = "1.14.1.post1"
 dependencies = [
     "numpy>=2,<3",
     "packaging",


### PR DESCRIPTION
## Summary

- Upstream FAISS deleted and re-released the `v1.14.1` tag ([events log](https://api.github.com/repos/facebookresearch/faiss/events)), changing the commit from `471ddad` to `5622e93`😇
- Updated faiss submodule to point to the new v1.14.1 commit (`5622e93`)
- Bumped version to `1.14.1.post1` since PyPI does not allow re-uploading the same version